### PR TITLE
fix: channel packager/host/port must be properties not attributes

### DIFF
--- a/tutorials/channel-adaptor/src/dist/deploy/10_channel.xml
+++ b/tutorials/channel-adaptor/src/dist/deploy/10_channel.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <channel-adaptor name="upstream" logger="Q2">
-  <channel class="org.jpos.iso.channel.XMLChannel"
-           logger="Q2"
-           packager="org.jpos.iso.packager.XMLPackager"
-           host="${upstream.host}"
-           port="${upstream.port}" />
+  <channel class="org.jpos.iso.channel.XMLChannel" logger="Q2">
+    <property name="packager" value="org.jpos.iso.packager.XMLPackager"/>
+    <property name="host"     value="${upstream.host}"/>
+    <property name="port"     value="${upstream.port}"/>
+  </channel>
   <in>upstream-send</in>
   <out>upstream-receive</out>
   <reconnect-delay>10000</reconnect-delay>

--- a/tutorials/logon-manager/src/dist/deploy/10_channel.xml
+++ b/tutorials/logon-manager/src/dist/deploy/10_channel.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <channel-adaptor name="upstream" logger="Q2">
-  <channel class="org.jpos.iso.channel.XMLChannel"
-           logger="Q2"
-           packager="org.jpos.iso.packager.XMLPackager"
-           host="${upstream.host}"
-           port="${upstream.port}" />
+  <channel class="org.jpos.iso.channel.XMLChannel" logger="Q2">
+    <property name="packager" value="org.jpos.iso.packager.XMLPackager"/>
+    <property name="host"     value="${upstream.host}"/>
+    <property name="port"     value="${upstream.port}"/>
+  </channel>
   <in>upstream-send</in>
   <out>upstream-receive</out>
   <reconnect-delay>10000</reconnect-delay>

--- a/tutorials/muxpool/src/dist/deploy/10_channel_a.xml
+++ b/tutorials/muxpool/src/dist/deploy/10_channel_a.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <channel-adaptor name="upstream-a" logger="Q2">
-  <channel class="org.jpos.iso.channel.XMLChannel"
-           logger="Q2"
-           packager="org.jpos.iso.packager.XMLPackager"
-           host="${upstream.host}"
-           port="${upstream.port}" />
+  <channel class="org.jpos.iso.channel.XMLChannel" logger="Q2">
+    <property name="packager" value="org.jpos.iso.packager.XMLPackager"/>
+    <property name="host"     value="${upstream.host}"/>
+    <property name="port"     value="${upstream.port}"/>
+  </channel>
   <in>upstream-a-send</in>
   <out>upstream-a-receive</out>
   <reconnect-delay>10000</reconnect-delay>

--- a/tutorials/muxpool/src/dist/deploy/10_channel_b.xml
+++ b/tutorials/muxpool/src/dist/deploy/10_channel_b.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <channel-adaptor name="upstream-b" logger="Q2">
-  <channel class="org.jpos.iso.channel.XMLChannel"
-           logger="Q2"
-           packager="org.jpos.iso.packager.XMLPackager"
-           host="${upstream.host}"
-           port="${upstream.port}" />
+  <channel class="org.jpos.iso.channel.XMLChannel" logger="Q2">
+    <property name="packager" value="org.jpos.iso.packager.XMLPackager"/>
+    <property name="host"     value="${upstream.host}"/>
+    <property name="port"     value="${upstream.port}"/>
+  </channel>
   <in>upstream-b-send</in>
   <out>upstream-b-receive</out>
   <reconnect-delay>10000</reconnect-delay>

--- a/tutorials/qmux/src/dist/deploy/10_channel.xml
+++ b/tutorials/qmux/src/dist/deploy/10_channel.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <channel-adaptor name="upstream" logger="Q2">
-  <channel class="org.jpos.iso.channel.XMLChannel"
-           logger="Q2"
-           packager="org.jpos.iso.packager.XMLPackager"
-           host="${upstream.host}"
-           port="${upstream.port}" />
+  <channel class="org.jpos.iso.channel.XMLChannel" logger="Q2">
+    <property name="packager" value="org.jpos.iso.packager.XMLPackager"/>
+    <property name="host"     value="${upstream.host}"/>
+    <property name="port"     value="${upstream.port}"/>
+  </channel>
   <in>upstream-send</in>
   <out>upstream-receive</out>
   <reconnect-delay>10000</reconnect-delay>

--- a/tutorials/qserver/src/dist/deploy/50_server.xml
+++ b/tutorials/qserver/src/dist/deploy/50_server.xml
@@ -1,5 +1,6 @@
 <qserver logger="Q2" name="qserver">
  <attr name="port" type="java.lang.Integer">${qserver.port}</attr>
- <channel class="org.jpos.iso.channel.XMLChannel" logger="Q2" packager="org.jpos.iso.packager.XMLPackager" />
+ <channel class="org.jpos.iso.channel.XMLChannel" logger="Q2">
+   <property name="packager" value="org.jpos.iso.packager.XMLPackager"/>
+ </channel>
 </qserver>
-


### PR DESCRIPTION
Fixes all `<channel>` descriptors across channel-adaptor, qmux, logon-manager, muxpool, and qserver.

`host`, `port`, and `packager` are not XML attributes of the `<channel>` element — they are `<property>` children read via the QBean configuration mechanism.

**Before:**
```xml
<channel class="org.jpos.iso.channel.XMLChannel"
         logger="Q2"
         packager="org.jpos.iso.packager.XMLPackager"
         host="${upstream.host}"
         port="${upstream.port}" />
```

**After:**
```xml
<channel class="org.jpos.iso.channel.XMLChannel" logger="Q2">
  <property name="packager" value="org.jpos.iso.packager.XMLPackager"/>
  <property name="host"     value="${upstream.host}"/>
  <property name="port"     value="${upstream.port}"/>
</channel>
```

Companion site PR: ar/site (fix/channel-properties)