### PR TITLE
fix(dirpoll): add bin/q2, log/, cfg; use Logger in UpperCaseFileProcessor

### DIFF
--- a/tutorials/dirpoll/src/dist/bin/q2
+++ b/tutorials/dirpoll/src/dist/bin/q2
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+cd `dirname $0`/.. || exit 1
+rm -f deploy/shutdown.xml
+
+if [ -f jpos.pid ] && ps -p $(cat jpos.pid) > /dev/null 2>&1
+then
+   echo "Process $(cat jpos.pid) is running"
+else
+  rm -f jpos.pid
+  exec java -server \
+    -XX:+IgnoreUnrecognizedVMOptions \
+    -Xmx1G \
+    -Djava.net.preferIPv4Stack=true \
+    -jar @jarname@  --pid="jpos.pid" "$@"
+fi
+

--- a/tutorials/dirpoll/src/dist/bin/start
+++ b/tutorials/dirpoll/src/dist/bin/start
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+cd `dirname $0`
+echo Starting Q2
+nohup ./q2 "$@" > /dev/null 2>&1 &
+

--- a/tutorials/dirpoll/src/dist/bin/stop
+++ b/tutorials/dirpoll/src/dist/bin/stop
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+echo Stopping Q2
+cd $(dirname $0)/.. || exit 1
+if [ -f jpos.pid ] && ps -p $(cat jpos.pid) > /dev/null 2>&1; then
+    kill $(cat jpos.pid)
+else
+    echo '<shutdown/>' > deploy/shutdown.xml
+fi
+

--- a/tutorials/dirpoll/src/dist/cfg/default.yml
+++ b/tutorials/dirpoll/src/dist/cfg/default.yml
@@ -1,0 +1,2 @@
+dirpoll:
+  path: dirpoll

--- a/tutorials/dirpoll/src/main/java/org/jpos/tutorial/UpperCaseFileProcessor.java
+++ b/tutorials/dirpoll/src/main/java/org/jpos/tutorial/UpperCaseFileProcessor.java
@@ -19,6 +19,9 @@
 package org.jpos.tutorial;
 
 import org.jpos.util.DirPoll;
+import org.jpos.util.LogEvent;
+import org.jpos.util.Logger;
+import org.jpos.util.SimpleLogSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -27,23 +30,29 @@ import java.nio.file.Files;
 
 /**
  * A {@link DirPoll.FileProcessor} that upper-cases the content of each
- * incoming file and logs the result.
+ * incoming file and logs the result via the jPOS logger.
+ *
+ * <p>Implementing {@link org.jpos.util.LogSource} (via {@link SimpleLogSource})
+ * allows {@code DirPollAdaptor} to inject the Q2 logger automatically.
+ * Using {@link Logger#log} directly is the idiomatic jPOS approach: it
+ * produces properly structured log events with realm and timestamp, and
+ * avoids the 500 ms batching delay of {@code LogEventOutputStream} that
+ * backs the {@code redirect=stdout} capture mechanism.
  *
  * <p>{@link DirPoll.FileProcessor} receives a {@link File} handle pointing
  * to the request file after DirPoll has moved it into the {@code run/}
- * directory.  The processor is responsible for everything: reading, acting,
- * and deciding what to do next.  DirPoll will archive or delete the file
- * once {@link #process(File)} returns normally.
+ * directory.  DirPoll archives or deletes the file once
+ * {@link #process(File)} returns normally.
  *
  * <p>Unlike {@link DirPoll.Processor}, a {@code FileProcessor} does not
  * return a byte array.  If you need to write a response file, create it
- * directly in the {@code response/} directory (or any other directory)
- * from within this method.
+ * directly in the {@code response/} directory from within this method.
  */
-public class UpperCaseFileProcessor implements DirPoll.FileProcessor {
+public class UpperCaseFileProcessor extends SimpleLogSource
+        implements DirPoll.FileProcessor {
 
     /**
-     * Upper-case the content of the request file and print it to stdout.
+     * Upper-case the content of the request file and log the result.
      *
      * @param file the request file, already moved to the {@code run/} directory
      * @throws DirPoll.DirPollException on processing errors;
@@ -53,7 +62,12 @@ public class UpperCaseFileProcessor implements DirPoll.FileProcessor {
     public void process(File file) throws DirPoll.DirPollException {
         try {
             String content = Files.readString(file.toPath(), StandardCharsets.UTF_8);
-            System.out.println("Processed [" + file.getName() + "]: " + content.trim().toUpperCase());
+            String upper   = content.trim().toUpperCase();
+
+            LogEvent evt = new LogEvent(this, "upper-case-processor");
+            evt.addMessage("file: " + file.getName());
+            evt.addMessage("result: " + upper);
+            Logger.log(evt);
         } catch (IOException e) {
             throw new DirPoll.DirPollException("Error reading " + file.getName(), e);
         }


### PR DESCRIPTION
Fixes for the dirpoll tutorial module that missed the merge window of PR #15.

## Changes
- `src/dist/bin/q2` (+ start/stop): required by the Gradle `run` task, which executes `./bin/q2`
- `src/dist/log/.gitkeep`: `RotateLogListener` throws `ConfigurationException` if `log/` is absent, causing `LoggerAdaptor.startService()` to abort before the `redirect=stdout` capture is installed
- `src/dist/cfg/default.yml`: standard Q2 env config
- `UpperCaseFileProcessor`: extend `SimpleLogSource` + use `Logger.log()` — idiomatic jPOS; avoids the 500ms `LogEventOutputStream` batch delay

Companion docs PR: ar/site (fix/dirpoll-logging-doc)