### PR TITLE
bump: upgrade jPOS Gradle plugin 0.0.16 → 0.0.17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.jpos.jposapp' version '0.0.16' apply false
+    id 'org.jpos.jposapp' version '0.0.17' apply false
     id 'idea'
 }
 


### PR DESCRIPTION
Bumps the jPOS Gradle plugin from `0.0.16` to `0.0.17` in `build.gradle`.

**What's new in 0.0.17:**
- `extraPaths` configuration for `distnc`/`zipnc` tasks
- `GitRevisionTask` now uses `FileRepositoryBuilder.findGitDir()` — works correctly in multi-module repos and non-git projects
- Toolchain upgrade to Java 25.0.2-amzn / Gradle 9.4.0

**Build status:** all previously-passing modules still pass ✅ (`channel-adaptor`, `dirpoll`, `logon-manager`, `qbean-primer`, `qbean-support`, `qserver`, `transaction-manager`). The `qmux` and `muxpool` failures are pre-existing (wrong `ISOUtil` import path) and unrelated to this bump.