### PR TITLE
Rename qmux to upstream-mux in XML configuration

### DIFF
--- a/tutorials/qmux/src/dist/deploy/20_qmux.xml
+++ b/tutorials/qmux/src/dist/deploy/20_qmux.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<qmux name="upstream" logger="Q2">
+<qmux name="upstream-mux" logger="Q2">
   <in>upstream-receive</in>
   <out>upstream-send</out>
   <ready>upstream.ready</ready>


### PR DESCRIPTION
<exception name="upstream has already been deployed in another file.">