### PR TITLE
fix(deploy): rename channel-adaptors to avoid JMX name collision with qmux beans

### DIFF
--- a/tutorials/muxpool/src/dist/deploy/10_channel_a.xml
+++ b/tutorials/muxpool/src/dist/deploy/10_channel_a.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<channel-adaptor name="upstream-a" logger="Q2">
+<channel-adaptor name="upstream-a-channel" logger="Q2">
   <channel class="org.jpos.iso.channel.XMLChannel" logger="Q2" packager="org.jpos.iso.packager.XMLPackager">
     <property name="host"     value="${upstream.host}"/>
     <property name="port"     value="${upstream.port}"/>

--- a/tutorials/muxpool/src/dist/deploy/10_channel_b.xml
+++ b/tutorials/muxpool/src/dist/deploy/10_channel_b.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<channel-adaptor name="upstream-b" logger="Q2">
+<channel-adaptor name="upstream-b-channel" logger="Q2">
   <channel class="org.jpos.iso.channel.XMLChannel" logger="Q2" packager="org.jpos.iso.packager.XMLPackager">
     <property name="host"     value="${upstream.host}"/>
     <property name="port"     value="${upstream.port}"/>

--- a/tutorials/qmux/src/dist/deploy/10_channel.xml
+++ b/tutorials/qmux/src/dist/deploy/10_channel.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<channel-adaptor name="upstream" logger="Q2">
+<channel-adaptor name="upstream-channel" logger="Q2">
   <channel class="org.jpos.iso.channel.XMLChannel" logger="Q2" packager="org.jpos.iso.packager.XMLPackager">
     <property name="host"     value="${upstream.host}"/>
     <property name="port"     value="${upstream.port}"/>


### PR DESCRIPTION
Both `channel-adaptor` and `qmux` beans shared the same `name` attribute (`upstream`, `upstream-a`, `upstream-b`). On startup, Q2 registers each deployed bean as `Q2:type=qbean,service=<name>` in the platform MBeanServer. When the qmux bean attempted to register under the same name already taken by the channel-adaptor, Q2 caught the `InstanceAlreadyExistsException` and renamed the qmux deploy file to `.DUP` — silently leaving the qmux undeployed.

Fix: rename the channel-adaptors to `upstream-channel`, `upstream-a-channel`, `upstream-b-channel`. The qmux logical names remain unchanged since they are the names consumers (logon-manager, send-request) reference.

Also incorporates the `packager` attribute form from the recently merged PRs #22, #27, #28.