### PR TITLE
fix(qmux): update ready key to match renamed channel-adaptor

### DIFF
--- a/tutorials/qmux/src/dist/deploy/20_qmux.xml
+++ b/tutorials/qmux/src/dist/deploy/20_qmux.xml
@@ -3,7 +3,7 @@
 <qmux name="upstream" logger="Q2">
   <in>upstream-receive</in>
   <out>upstream-send</out>
-  <ready>upstream.ready</ready>
+  <ready>upstream-channel.ready</ready>
   <unhandled>unhandled</unhandled>
   <key>11</key>
 </qmux>


### PR DESCRIPTION
Follow-up to PR #34. When the channel-adaptor was renamed from `upstream` to `upstream-channel`, the `<ready>` key in `20_qmux.xml` was not updated. The qmux derives the ready signal from the channel-adaptor bean name, so it must be `upstream-channel.ready` to match.

PRs #35 and #36 fixed the same issue in the muxpool tutorial.